### PR TITLE
Fix SIGABRT on iOS 26.5 when host bundle id lookup returns NULL

### DIFF
--- a/Sources/KeyboardKit/Host/KeyboardInputViewController+Host.swift
+++ b/Sources/KeyboardKit/Host/KeyboardInputViewController+Host.swift
@@ -51,13 +51,13 @@ private extension KeyboardInputViewController {
            let con = info.perform(NSSelectorFromString("connection")).takeUnretainedValue() as? NSObjectProtocol
         else { return nil }
         let xpcCon = con.perform(NSSelectorFromString("_xpcConnection")).takeUnretainedValue()
-        let handle = dlopen("/usr/lib/libc.dylib", RTLD_NOW)
-        let sym = dlsym(handle, "xpc_connection_copy_bundle_id")
-        typealias xpcFunc = @convention(c) (AnyObject) -> UnsafePointer<CChar>
+        guard let handle = dlopen("/usr/lib/libc.dylib", RTLD_NOW),
+              let sym = dlsym(handle, "xpc_connection_copy_bundle_id")
+        else { return nil }
+        typealias xpcFunc = @convention(c) (AnyObject) -> UnsafePointer<CChar>?
         let cFunc = unsafeBitCast(sym, to: xpcFunc.self)
-        let response = cFunc(xpcCon)
-        let hostBundleId = NSString(utf8String: response)
-        return hostBundleId as String?
+        guard let response = cFunc(xpcCon) else { return nil }
+        return String(cString: response)
     }
 }
 #endif


### PR DESCRIPTION
xpc_connection_copy_bundle_id can return NULL for keyboard extensions on iOS 26.5, but the typealias declared a non-optional return type, so the NULL pointer was passed straight into NSString.init(utf8String:), which throws NSInvalidArgumentException. Swift cannot catch ObjC exceptions, so the extension aborts on every KeyboardContext.sync.

Make the typealias optional, guard the result, and use String(cString:) on the unwrapped pointer. Also guard dlopen/dlsym for defense in depth. Falls back to nil on any failure; callers already handle nil since hostApplicationBundleId is String?.